### PR TITLE
Netcdf5.x

### DIFF
--- a/R/getVerticalLevelPars.R
+++ b/R/getVerticalLevelPars.R
@@ -27,6 +27,8 @@ getVerticalLevelPars <- function(grid, level) {
         level <- levels
         if (gcs$getVerticalAxis()$findCoordElement(level) < 0) {
           levelInd <- gcs$getVerticalAxis()$findCoordElement(0)
+        } else {
+          levelInd <- gcs$getVerticalAxis()$findCoordElement(level)
         }
       } else {
         stop("Variable with vertical levels: '@level' following the variable name is required\nPossible values: ", paste(levels, collapse = ", "))
@@ -39,11 +41,7 @@ getVerticalLevelPars <- function(grid, level) {
       }
     }
     zRange <- .jnew("ucar/ma2/Range", levelInd, levelInd)
-  } else {
-    if (!is.null(level)) {
-      # warning("The variable selected is 2D: the '@level' specification was ignored")
-      level <- level
-    }
+  } else { 
     zRange <- .jnull()
   }
   return(list("level" = level, "zRange" = zRange))

--- a/R/makeSubset.R
+++ b/R/makeSubset.R
@@ -95,7 +95,8 @@ makeSubset <- function(grid, timePars, levelPars, latLon, memberPars) {
           aux.pointXYindex <- as.integer(c(0))
         } else {
           ## aux.pointXYindex <- as.integer(which(c(latLon$llRanges[[j]]$get(1L)$min():latLon$llRanges[[j]]$get(1L)$max()) == latLon$pointXYindex[1]) -1)
-           aux.pointXYindex <- as.integer(which(c(latLon$llRanges[[j]]$get(0L)$min():latLon$llRanges[[j]]$get(0L)$max()) == latLon$pointXYindex[1]) -1)
+          ## aux.pointXYindex <- as.integer(which(c(latLon$llRanges[[j]]$get(0L)$min():latLon$llRanges[[j]]$get(0L)$max()) == latLon$pointXYindex[1]) -1)
+          aux.pointXYindex <- as.integer(which(c(latLon$llRanges[[j]]$get(0L)$first():latLon$llRanges[[j]]$get(0L)$last()) == latLon$pointXYindex[1]) -1)
         }
         aux.list2[[j]] <- array(subSet$readDataSlice(-1L, -1L, -1L, -1L,
                                                      latLon$pointXYindex[2],


### PR DESCRIPTION
### NetCDF-Java 5.X Compatibility Updates

This PR introduces compatibility fixes in loadeR to support recent NetCDF-Java 5.X jars, while maintaining backward compatibility with older jars (e.g., 4.6.0). The changes were identified through `testthat` tests, which currently cover ~80% of loadeR, and failed only in these specific places when using updated jars.

These changes are submitted for review with the intention of being included in a new `minor release`.

#### Changes:
1. **makeSubset.R**
   - **Problem**: In NetCDF-Java 5.X, the `min()` and `max()` methods are no longer available.  
   - **Fix**: Replaced them with the corresponding methods `first()` and `last()`.  
   - **Before**:
     ```r
     aux.pointXYindex <- as.integer(which(c(latLon$llRanges[[j]]$get(0L)$min():latLon$llRanges[[j]]$get(0L)$max()) == latLon$pointXYindex[1]) -1)
     ```
   - **After**:
     ```r
     aux.pointXYindex <- as.integer(which(c(latLon$llRanges[[j]]$get(0L)$first():latLon$llRanges[[j]]$get(0L)$last()) == latLon$pointXYindex[1]) -1)
     ```

2. **getVerticalLevelPars.R**
   - **Problem**: When grids have only a single vertical level (e.g., `850`), and the function `getVerticalLevelPars()` is called with `level = NULL`, the expectation is that this unique level is selected automatically. Internally, the function uses a variable `levelInd` to represent the index of that single level.  
     - With **older jars**: calling `findCoordElement(level)` returned `-1`, so the fallback forced `levelInd <- gcs$getVerticalAxis()$findCoordElement(0)` which correctly assigned index `0`.  
     - With **recent jars**: calling `findCoordElement(level)` succeeds and returns a valid index, but the original code only covered the `< 0` (fallback) case. As a result, `levelInd` was never assigned and errors occurred.  
   - **Fix**: Add an explicit `else` branch to handle the case where the lookup succeeds, assigning the index correctly.  
   - **Before**:
     ```r
     if (gcs$getVerticalAxis()$findCoordElement(level) < 0) {
       levelInd <- gcs$getVerticalAxis()$findCoordElement(0)
     }
     ```
   - **After**:
     ```r
     if (gcs$getVerticalAxis()$findCoordElement(level) < 0) {
       levelInd <- gcs$getVerticalAxis()$findCoordElement(0)
     } else {
       levelInd <- gcs$getVerticalAxis()$findCoordElement(level)
     }
     ```
   - **Note**: It was tested whether setting `level <- levels[1]` (instead of `level <- levels`) would allow `findCoordElement(level)` to work in older jars, but the behavior remains the same (returning `-1`). Therefore, the fallback + explicit success branch is required to cover both old and recent jars.
